### PR TITLE
Make /q available in supergroups.

### DIFF
--- a/app/Commands/QuoteCommand.php
+++ b/app/Commands/QuoteCommand.php
@@ -32,7 +32,7 @@ class QuoteCommand extends BaseCommand
         // Detect a reply and add it as a quote
         $quoteSource = $message->getReplyToMessage();
         if ($quoteSource) {
-            if ($this->getUpdate()->getMessage()->getChat()->getType() != 'group') {
+            if (in_array(['group', 'supergroup'], $this->getUpdate()->getMessage()->getChat()->getType())) {
                 $this->reply('You can only add quotes in a group.');
 
                 return;


### PR DESCRIPTION
On the quotes command, it checks if the chat type is a `group`. However, supergroups have their own chat type, `supergroup`. I fixed it to check for either of those types.